### PR TITLE
Adding path.Close()

### DIFF
--- a/abs.go
+++ b/abs.go
@@ -161,6 +161,7 @@ func (c *Canvas) AbsPolygon(x, y []float32, fillcolor color.NRGBA) {
 	}
 	path.Line(f32.Point{X: x[0] - x[l-1], Y: y[0] - y[l-1]})
 	path.Line(point)
+	path.Close()
 	clip.Outline{Path: path.End()}.Op().Add(ops)
 	paint.ColorOp{Color: fillcolor}.Add(ops)
 	paint.PaintOp{}.Add(ops)


### PR DESCRIPTION
By closing the path, the canvas can be resized dynamically by inheriting constraints form the parent in the layout structure.

With this fix, one can set the size of the canvas through the constrains handed down to it from it's parent in the layout structure. That allows for dynamic canvas size. 

I've gif'ed it in this tweet. The width of the canvas is set through gtx.Constraints.Max.X, while the height is hardcoded to 500. 
https://twitter.com/jonegilstrand/status/1452352259963117570

Without path.close(), resizing throws a "panic path not closed".  With the explicit close, it's all good.


I have not gone through the rest of the code to check if a path.close() should be included. 


By the way, I could share with you the example program behind the gif to the issue raised on giocanvas?

